### PR TITLE
Fixed Bazaar DC

### DIFF
--- a/Lib K Relay/Networking/StateManager.cs
+++ b/Lib K Relay/Networking/StateManager.cs
@@ -79,6 +79,10 @@ namespace Lib_K_Relay.Networking
                         resolvedState.LastRealm = randomRealmState.LastRealm;
                         _proxy.States.Remove(randomRealmState.GUID);
                     }
+                    else if (resolvedState.LastHello.GameId == -2)
+                    {
+                        resolvedState.ConTargetAddress = Proxy.DefaultServer;
+                    }
                 }
             }
 


### PR DESCRIPTION
Con target address of resolved state was that of its realm, so when it tried to connect it used the realms ip rather than the nexus.